### PR TITLE
Fix vertex buffer size calculation: pIndexData wasn't set in DrawContext

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7408,6 +7408,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVertices)
 		DrawContext.dwVertexCount = VertexCount;
 		DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
 		DrawContext.dwIndexBase = indexBase; // Used by GetVertexBufferSize
+		DrawContext.pIndexData = pIndexData; // Used by GetVertexBufferSize
 
 		// Test case JSRF draws all geometry through this function (only sparks are drawn via another method)
 		// using X_D3DPT_TRIANGLELIST and X_D3DPT_TRIANGLESTRIP PrimitiveType


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/740003/39692880-21f13132-51da-11e8-9f27-44856494bc61.png)

After:
![image](https://user-images.githubusercontent.com/740003/39692882-26f5477c-51da-11e8-86fc-b75c8666965d.png)
