### PR TITLE
Add index buffer walk through for all indexed rendering calls.

### DIFF
--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -6977,6 +6977,24 @@ void CxbxDrawIndexedClosingLineUP(XTL::INDEX16 LowIndex, XTL::INDEX16 HighIndex,
 }
 
 // TODO : Move to own file
+//Walk through index buffer
+void WalkIndexBuffer(UINT16 & LowIndex, UINT16 & HighIndex, void * pIndexDataInput,DWORD dwVertexCount)
+{
+	int iIndexCounts = (int)dwVertexCount;
+	// Determine highest and lowest index in use 
+	UINT16 * pIndexData = (UINT16*)pIndexDataInput;
+	LowIndex = pIndexData[0];
+	HighIndex = LowIndex;
+	for (int i = 1; i < iIndexCounts; i++) {
+		UINT16 Index = pIndexData[i];
+		if (LowIndex > Index)
+			LowIndex = Index;
+		if (HighIndex < Index)
+			HighIndex = Index;
+	}
+	return;
+}
+
 // Requires assigned pIndexData
 // Called by D3DDevice_DrawIndexedVertices and EmuExecutePushBufferRaw (twice)
 void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData)
@@ -7030,19 +7048,9 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData)
 	}
 	else {
 		//Walk through index buffer
-		INDEX16* pWalkIndexData = (INDEX16*)pIndexData;
-		int iIndexCounts = (int)DrawContext.dwVertexCount; 
 		// Determine highest and lowest index in use :
-		INDEX16 LowIndex = pWalkIndexData[0];
-		INDEX16 HighIndex = LowIndex;
-		for (int i = 1; i < iIndexCounts; i++) {
-			INDEX16 Index = pWalkIndexData[i];
-			if (LowIndex > Index)
-				LowIndex = Index;
-			if (HighIndex < Index)
-				HighIndex = Index;
-		}
-		
+		INDEX16 LowIndex, HighIndex;
+		WalkIndexBuffer( LowIndex,  HighIndex, pIndexData, DrawContext.dwVertexCount);
 		// Primitives other than X_D3DPT_QUADLIST can be drawn using one DrawIndexedPrimitive call :
 		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitive(
 			EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
@@ -7099,18 +7107,9 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 		UINT PrimitiveCount = DrawContext.dwHostPrimitiveCount * TRIANGLES_PER_QUAD;
 		
 		//walk through index buffer
-		INDEX16* pWalkIndexData = (INDEX16*)pIndexData;
-		int iIndexCounts = (int)DrawContext.dwVertexCount+ (int)DrawContext.dwVertexCount/2; //we use a new index buffer to draw the QUAD List, the index buffer index counts differes from original Vertex count.
-		// Determine highest and lowest index in use :
-		INDEX16 LowIndex = pWalkIndexData[0];
-		INDEX16 HighIndex = LowIndex;
-		for (int i = 1; i < iIndexCounts; i++) {
-			INDEX16 Index = pWalkIndexData[i];
-			if (LowIndex > Index)
-				LowIndex = Index;
-			if (HighIndex < Index)
-				HighIndex = Index;
-		}
+		INDEX16 LowIndex, HighIndex;
+		WalkIndexBuffer(LowIndex, HighIndex,pIndexData, DrawContext.dwVertexCount);
+
 
 		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 			D3DPT_TRIANGLELIST, // Draw indexed triangles instead of quads
@@ -7542,19 +7541,9 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 		}
 		else {
 			//walk through the index buffer
-			INDEX16* pWalkIndexData = (INDEX16*)pIndexData;
-			int iIndexCounts = (int)VertexCount;
-				// Determine highest and lowest index in use :
-			INDEX16 LowIndex = pWalkIndexData[0];
-			INDEX16 HighIndex = LowIndex;
-			for (int i = 1; i < iIndexCounts; i++) {
-				INDEX16 Index = pWalkIndexData[i];
-				if (LowIndex > Index)
-					LowIndex = Index;
-				if (HighIndex < Index)
-					HighIndex = Index;
-			}
-			
+			INDEX16 LowIndex, HighIndex;
+			WalkIndexBuffer( LowIndex,  HighIndex, pIndexData, DrawContext.dwVertexCount);
+
 			// LOG_TEST_CASE("DrawIndexedPrimitiveUP"); // Test-case : Burnout, Namco Museum 50th Anniversary
 			HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 				EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),

--- a/src/CxbxKrnl/EmuD3D8.cpp
+++ b/src/CxbxKrnl/EmuD3D8.cpp
@@ -7029,14 +7029,28 @@ void XTL::CxbxDrawIndexed(CxbxDrawContext &DrawContext, INDEX16 *pIndexData)
 		}
 	}
 	else {
+		//Walk through index buffer
+		INDEX16* pWalkIndexData = (INDEX16*)pIndexData;
+		int iIndexCounts = (int)DrawContext.dwVertexCount; 
+		// Determine highest and lowest index in use :
+		INDEX16 LowIndex = pWalkIndexData[0];
+		INDEX16 HighIndex = LowIndex;
+		for (int i = 1; i < iIndexCounts; i++) {
+			INDEX16 Index = pWalkIndexData[i];
+			if (LowIndex > Index)
+				LowIndex = Index;
+			if (HighIndex < Index)
+				HighIndex = Index;
+		}
+		
 		// Primitives other than X_D3DPT_QUADLIST can be drawn using one DrawIndexedPrimitive call :
 		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitive(
 			EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
 #ifdef CXBX_USE_D3D9
 			g_CachedIndexBase, // ??
 #endif
-			/* MinVertexIndex = */0,
-			/* NumVertices = */DrawContext.dwVertexCount, // TODO : g_EmuD3DActiveStreamSizes[0], // Note : ATI drivers are especially picky about this -
+			/* MinVertexIndex = */LowIndex,
+			/* NumVertices = */HighIndex-LowIndex+1,//using index vertex span here.  // TODO : g_EmuD3DActiveStreamSizes[0], // Note : ATI drivers are especially picky about this -
 			// NumVertices should be the span of covered vertices in the active vertex buffer (TODO : Is stream 0 correct?)
 			DrawContext.dwStartVertex,
 			DrawContext.dwHostPrimitiveCount);
@@ -7083,10 +7097,25 @@ void XTL::CxbxDrawPrimitiveUP(CxbxDrawContext &DrawContext)
 		INDEX16 *pIndexData = CxbxAssureQuadListIndexBuffer(DrawContext.dwVertexCount);
 		// Convert quad vertex-count to triangle vertex count :
 		UINT PrimitiveCount = DrawContext.dwHostPrimitiveCount * TRIANGLES_PER_QUAD;
+		
+		//walk through index buffer
+		INDEX16* pWalkIndexData = (INDEX16*)pIndexData;
+		int iIndexCounts = (int)DrawContext.dwVertexCount+ (int)DrawContext.dwVertexCount/2; //we use a new index buffer to draw the QUAD List, the index buffer index counts differes from original Vertex count.
+		// Determine highest and lowest index in use :
+		INDEX16 LowIndex = pWalkIndexData[0];
+		INDEX16 HighIndex = LowIndex;
+		for (int i = 1; i < iIndexCounts; i++) {
+			INDEX16 Index = pWalkIndexData[i];
+			if (LowIndex > Index)
+				LowIndex = Index;
+			if (HighIndex < Index)
+				HighIndex = Index;
+		}
+
 		HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 			D3DPT_TRIANGLELIST, // Draw indexed triangles instead of quads
-			0, // MinVertexIndex
-			DrawContext.dwVertexCount, // NumVertexIndices
+			LowIndex, // MinVertexIndex
+			HighIndex-LowIndex+1, // NumVertexIndices
 			PrimitiveCount,
 			pIndexData,
 			D3DFMT_INDEX16,
@@ -7464,7 +7493,7 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 		CxbxDrawContext DrawContext = {};
 
 		DrawContext.XboxPrimitiveType = PrimitiveType;
-		DrawContext.dwVertexCount = VertexCount;
+		DrawContext.dwVertexCount = VertexCount; 
 		DrawContext.pXboxVertexStreamZeroData = pVertexStreamZeroData;
 		DrawContext.uiXboxVertexStreamZeroStride = VertexStreamZeroStride;
 		DrawContext.hVertexShader = g_CurrentXboxVertexShaderHandle;
@@ -7512,11 +7541,25 @@ VOID WINAPI XTL::EMUPATCH(D3DDevice_DrawIndexedVerticesUP)
 			g_dwPrimPerFrame += VertexCount / VERTICES_PER_QUAD * TRIANGLES_PER_QUAD;
 		}
 		else {
+			//walk through the index buffer
+			INDEX16* pWalkIndexData = (INDEX16*)pIndexData;
+			int iIndexCounts = (int)VertexCount;
+				// Determine highest and lowest index in use :
+			INDEX16 LowIndex = pWalkIndexData[0];
+			INDEX16 HighIndex = LowIndex;
+			for (int i = 1; i < iIndexCounts; i++) {
+				INDEX16 Index = pWalkIndexData[i];
+				if (LowIndex > Index)
+					LowIndex = Index;
+				if (HighIndex < Index)
+					HighIndex = Index;
+			}
+			
 			// LOG_TEST_CASE("DrawIndexedPrimitiveUP"); // Test-case : Burnout, Namco Museum 50th Anniversary
 			HRESULT hRet = g_pD3DDevice->DrawIndexedPrimitiveUP(
 				EmuXB2PC_D3DPrimitiveType(DrawContext.XboxPrimitiveType),
-				0, // MinVertexIndex
-				DrawContext.dwVertexCount, // NumVertexIndices
+				LowIndex, // MinVertexIndex
+				HighIndex-LowIndex+1, //this shall be Vertex Spans DrawContext.dwVertexCount, // NumVertexIndices
 				DrawContext.dwHostPrimitiveCount,
 				pIndexData,
 				D3DFMT_INDEX16,

--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -298,7 +298,9 @@ extern void XTL::EmuExecutePushBufferRaw
             pVertexData = pdwPushData;
 			//move pushpuffer to the end of vertex data.
             pdwPushData += dwCount;
-
+			if (dwCount == 0) {
+				continue;
+			}
             // retrieve vertex shader
 			DWORD dwVertexShader = g_CurrentXboxVertexShaderHandle;
 


### PR DESCRIPTION
Add index buffer walk through for all indexed rendering calls.
using correct min. index and indexed vertexes span.
also skip dwCount=0 case for method 0x1818.