### PR TITLE
only warning for possible non-FVF push buffer emulation instead of shut down emu.

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -306,10 +306,9 @@ extern void XTL::EmuExecutePushBufferRaw
 
 			if (VshHandleIsVertexShader(dwVertexShader)) 
 			{
-                CxbxKrnlCleanup("Non-FVF Vertex Shaders not yet supported for PushBuffer emulation!");
-                dwVertexShader = 0;
+                EmuWarning("Non-FVF Vertex Shaders not yet supported for PushBuffer emulation!");
             }
-            else if(dwVertexShader == 0)
+            if(dwVertexShader == 0)
             {
                 EmuWarning("FVF Vertex Shader is null");
                 dwVertexShader = -1;


### PR DESCRIPTION
This will enable certain to get in game such as RalliSport.
So far I see no regressions.
