### PR TITLE
skip possible non-FVF push buffer rendering.

### DIFF
--- a/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
+++ b/src/CxbxKrnl/EmuD3D8/PushBuffer.cpp
@@ -307,6 +307,7 @@ extern void XTL::EmuExecutePushBufferRaw
 			if (VshHandleIsVertexShader(dwVertexShader)) 
 			{
                 EmuWarning("Non-FVF Vertex Shaders not yet supported for PushBuffer emulation!");
+				continue;
             }
             if(dwVertexShader == 0)
             {


### PR DESCRIPTION
this makes RalliSport renders in a clear scene.